### PR TITLE
Add a rule for MSHTA to mitigate bypass

### DIFF
--- a/sysmon_rules.xml
+++ b/sysmon_rules.xml
@@ -384,4 +384,10 @@ updated by @nissy34
         <field name="win.eventdata.commandline">AppData</field>
         <description>Detects a suspicious command line execution that includes an URL and AppData</description>
     </rule>
+    
+    <rule id="255072" level="12">
+        <if_group>sysmon_event1</if_group>
+        <field name="win.eventdata.Image">\\mshta.exe</field>
+        <description>Sysmon - mshta.exe</description>
+    </rule>
 </group>


### PR DESCRIPTION
The current rules for mshta execution detection rely on using the parentImage field. However, it seems like it is possible to bypass that field entirely by executing programs through PowerShell. I have included a demo video where you can see that using cmd.exe correctly fills the parentImage field, but using powershell.exe does not.

https://user-images.githubusercontent.com/6316541/126476873-3ada97bb-9ed1-4d82-b729-c82187d596fa.mp4

My proposed solution is to add a new rule that triggers every time mshta is ran.
